### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/openwrt-luci-app-collection/security/code-scanning/1](https://github.com/Jackie264/openwrt-luci-app-collection/security/code-scanning/1)

The best way to fix this issue is to explicitly declare the minimal required permissions for the job. For most steps, only `read` access to repository contents is needed; however, the release upload step (`softprops/action-gh-release`) requires the ability to write to release assets, which in GitHub Actions means `contents: write`. The recommended approach is to create a `permissions` block under the `build` job, right before `runs-on:`. If you want stricter scoping (e.g., only allow `contents: write` for the specific release upload step), you would need split jobs, but it is safest and most maintainable to add:

```yaml
permissions:
  contents: write
```

just before `runs-on: ubuntu-latest`. This sets `contents: write` to the job, which covers both release upload and basic repo access. If you want to restrict further, set at the step-level (but softprops/action-gh-release does not support step-level permissions at this time).

Edit `.github/workflows/build.yml`, add these lines between line 9 (job name) and line 10 (`runs-on: ubuntu-latest`):

```yaml
permissions:
  contents: write
```

No imports or extra dependencies are needed; this is a YAML-only change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
